### PR TITLE
feat: support intrusive_adapter! access nested field

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [1.56.1, stable, beta, nightly]
+        rust: [1.82.0, stable, beta, nightly]
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/src/key_adapter.rs
+++ b/src/key_adapter.rs
@@ -29,14 +29,14 @@ use crate::pointer_ops::PointerOps;
 /// }
 ///
 /// // Adapter which returns a key by value
-/// intrusive_adapter!(MyAdapter = Box<S>: S { link : RBTreeLink });
+/// intrusive_adapter!(MyAdapter = Box<S>: S { link => RBTreeLink });
 /// impl<'a> KeyAdapter<'a> for MyAdapter {
 ///     type Key = u32;
 ///     fn get_key(&self, s: &'a S) -> u32 { s.key }
 /// }
 ///
 /// // Adapter which returns a key by reference
-/// intrusive_adapter!(MyAdapter2 = Box<S>: S { link : RBTreeLink });
+/// intrusive_adapter!(MyAdapter2 = Box<S>: S { link => RBTreeLink });
 /// impl<'a> KeyAdapter<'a> for MyAdapter2 {
 ///     type Key = &'a u32;
 ///     fn get_key(&self, s: &'a S) -> &'a u32 { &s.key }
@@ -51,7 +51,7 @@ use crate::pointer_ops::PointerOps;
 ///
 /// // Adapter which returns a tuple as a key. When used in a RBTree, this will
 /// // keep all elements sorted by `key1` first, then `key2` and finally `key3`.
-/// intrusive_adapter!(MyAdapter3 = Box<U>: U { link : RBTreeLink });
+/// intrusive_adapter!(MyAdapter3 = Box<U>: U { link => RBTreeLink });
 /// impl<'a> KeyAdapter<'a> for MyAdapter3 {
 ///     type Key = (i32, &'a str, f64);
 ///     fn get_key(&self, u: &'a U) -> Self::Key { (u.key1, &u.key2, u.key3) }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@
 //!
 //! // The adapter describes how an object can be inserted into an intrusive
 //! // collection. This is automatically generated using a macro.
-//! intrusive_adapter!(TestAdapter = Box<Test>: Test { link: LinkedListLink });
+//! intrusive_adapter!(TestAdapter = Box<Test>: Test { link => LinkedListLink });
 //!
 //! // Create a list and some objects
 //! let mut list = LinkedList::new(TestAdapter::new());
@@ -106,10 +106,10 @@
 //!     value: i32,
 //! }
 //!
-//! intrusive_adapter!(MyAdapter = Rc<Test>: Test { link: LinkedListLink });
-//! intrusive_adapter!(MyAdapter2 = Rc<Test>: Test { link2: SinglyLinkedListLink });
-//! intrusive_adapter!(MyAdapter3 = Rc<Test>: Test { link3: XorLinkedListLink });
-//! intrusive_adapter!(MyAdapter4 = Rc<Test>: Test { link4: RBTreeLink });
+//! intrusive_adapter!(MyAdapter = Rc<Test>: Test { link => LinkedListLink });
+//! intrusive_adapter!(MyAdapter2 = Rc<Test>: Test { link2 => SinglyLinkedListLink });
+//! intrusive_adapter!(MyAdapter3 = Rc<Test>: Test { link3 => XorLinkedListLink });
+//! intrusive_adapter!(MyAdapter4 = Rc<Test>: Test { link4 => RBTreeLink });
 //! impl<'a> KeyAdapter<'a> for MyAdapter4 {
 //!     type Key = i32;
 //!     fn get_key(&self, x: &'a Test) -> i32 { x.value }
@@ -158,7 +158,7 @@
 //!     value: i32,
 //! }
 //!
-//! intrusive_adapter!(ElementAdapter = Box<Element>: Element { link: RBTreeLink });
+//! intrusive_adapter!(ElementAdapter = Box<Element>: Element { link => RBTreeLink });
 //! impl<'a> KeyAdapter<'a> for ElementAdapter {
 //!     type Key = i32;
 //!     fn get_key(&self, e: &'a Element) -> i32 { e.value }
@@ -197,7 +197,7 @@
 //! }
 //!
 //! // Note that we use a plain reference as the pointer type for the collection.
-//! intrusive_adapter!(ValueAdapter<'a> = &'a Value: Value { link: LinkedListLink });
+//! intrusive_adapter!(ValueAdapter<'a> = &'a Value: Value { link => LinkedListLink });
 //!
 //! // Create an arena and a list. Note that since stack objects are dropped in
 //! // reverse order, the Arena must be created before the LinkedList. This

--- a/src/linked_list.rs
+++ b/src/linked_list.rs
@@ -1607,9 +1607,9 @@ mod tests {
             write!(f, "{}", self.value)
         }
     }
-    intrusive_adapter!(ObjAdapter1 = Rc<Obj>: Obj { link1: Link });
-    intrusive_adapter!(ObjAdapter2 = Rc<Obj>: Obj { link2: Link });
-    intrusive_adapter!(UnsafeRefObjAdapter1 = UnsafeRef<Obj>: Obj { link1: Link });
+    intrusive_adapter!(ObjAdapter1 = Rc<Obj>: Obj { link1 => Link });
+    intrusive_adapter!(ObjAdapter2 = Rc<Obj>: Obj { link2 => Link });
+    intrusive_adapter!(UnsafeRefObjAdapter1 = UnsafeRef<Obj>: Obj { link1 => Link });
 
     fn make_rc_obj(value: u32) -> Rc<Obj> {
         Rc::new(make_obj(value))
@@ -2009,7 +2009,7 @@ mod tests {
             link: Link,
             value: &'a T,
         }
-        intrusive_adapter!(ObjAdapter<'a, T> = &'a Obj<'a, T>: Obj<'a, T> {link: Link} where T: 'a);
+        intrusive_adapter!(ObjAdapter<'a, T> = &'a Obj<'a, T>: Obj<'a, T> {link => Link} where T: 'a);
 
         let v = 5;
         let a = Obj {
@@ -2033,7 +2033,7 @@ mod tests {
                 link: Link,
                 value: usize,
             }
-            intrusive_adapter!(ObjAdapter = $ptr<Obj>: Obj { link: Link });
+            intrusive_adapter!(ObjAdapter = $ptr<Obj>: Obj { link => Link });
 
             let a = $ptr::new(Obj {
                 link: Link::new(),

--- a/src/rbtree.rs
+++ b/src/rbtree.rs
@@ -2550,7 +2550,7 @@ mod tests {
             write!(f, "{}", self.value)
         }
     }
-    intrusive_adapter!(RcObjAdapter = Rc<Obj>: Obj { link: Link });
+    intrusive_adapter!(RcObjAdapter = Rc<Obj>: Obj { link => Link });
 
     impl<'a> KeyAdapter<'a> for RcObjAdapter {
         type Key = i32;
@@ -2559,7 +2559,7 @@ mod tests {
         }
     }
 
-    intrusive_adapter!(UnsafeRefObjAdapter = UnsafeRef<Obj>: Obj { link: Link });
+    intrusive_adapter!(UnsafeRefObjAdapter = UnsafeRef<Obj>: Obj { link => Link });
 
     impl<'a> KeyAdapter<'a> for UnsafeRefObjAdapter {
         type Key = i32;
@@ -3291,7 +3291,7 @@ mod tests {
             link: Link,
             value: &'a T,
         }
-        intrusive_adapter!(RcObjAdapter<'a, T> = &'a Obj<'a, T>: Obj<'a, T> {link: Link} where T: 'a);
+        intrusive_adapter!(RcObjAdapter<'a, T> = &'a Obj<'a, T>: Obj<'a, T> {link => Link} where T: 'a);
         impl<'a, 'b, T: 'a + 'b> KeyAdapter<'a> for RcObjAdapter<'b, T> {
             type Key = &'a T;
             fn get_key(&self, value: &'a Obj<'b, T>) -> &'a T {
@@ -3321,7 +3321,7 @@ mod tests {
                 link: Link,
                 value: usize,
             }
-            intrusive_adapter!(RcObjAdapter = $ptr<Obj>: Obj { link: Link });
+            intrusive_adapter!(RcObjAdapter = $ptr<Obj>: Obj { link => Link });
             impl<'a> KeyAdapter<'a> for RcObjAdapter {
                 type Key = usize;
                 fn get_key(&self, value: &'a Obj) -> usize {

--- a/src/singly_linked_list.rs
+++ b/src/singly_linked_list.rs
@@ -1299,9 +1299,9 @@ mod tests {
             write!(f, "{}", self.value)
         }
     }
-    intrusive_adapter!(RcObjAdapter1 = Rc<Obj>: Obj { link1: Link });
-    intrusive_adapter!(RcObjAdapter2 = Rc<Obj>: Obj { link2: Link });
-    intrusive_adapter!(UnsafeRefObjAdapter1 = UnsafeRef<Obj>: Obj { link1: Link });
+    intrusive_adapter!(RcObjAdapter1 = Rc<Obj>: Obj { link1 => Link });
+    intrusive_adapter!(RcObjAdapter2 = Rc<Obj>: Obj { link2 => Link });
+    intrusive_adapter!(UnsafeRefObjAdapter1 = UnsafeRef<Obj>: Obj { link1 => Link });
 
     fn make_rc_obj(value: u32) -> Rc<Obj> {
         Rc::new(make_obj(value))
@@ -1653,7 +1653,7 @@ mod tests {
             link: Link,
             value: &'a T,
         }
-        intrusive_adapter!(ObjAdapter<'a, T> = &'a Obj<'a, T>: Obj<'a, T> {link: Link} where T: 'a);
+        intrusive_adapter!(ObjAdapter<'a, T> = &'a Obj<'a, T>: Obj<'a, T> {link => Link} where T: 'a);
 
         let v = 5;
         let a = Obj {
@@ -1677,7 +1677,7 @@ mod tests {
                 link: Link,
                 value: usize,
             }
-            intrusive_adapter!(ObjAdapter = $ptr<Obj>: Obj { link: Link });
+            intrusive_adapter!(ObjAdapter = $ptr<Obj>: Obj { link => Link });
 
             let a = $ptr::new(Obj {
                 link: Link::new(),

--- a/src/xor_linked_list.rs
+++ b/src/xor_linked_list.rs
@@ -1790,9 +1790,9 @@ mod tests {
             write!(f, "{}", self.value)
         }
     }
-    intrusive_adapter!(RcObjAdapter1 = Rc<Obj>: Obj { link1: Link });
-    intrusive_adapter!(RcObjAdapter2 = Rc<Obj>: Obj { link2: Link });
-    intrusive_adapter!(UnsafeRefObjAdapter1 = UnsafeRef<Obj>: Obj { link1: Link });
+    intrusive_adapter!(RcObjAdapter1 = Rc<Obj>: Obj { link1 => Link });
+    intrusive_adapter!(RcObjAdapter2 = Rc<Obj>: Obj { link2 => Link });
+    intrusive_adapter!(UnsafeRefObjAdapter1 = UnsafeRef<Obj>: Obj { link1 => Link });
 
     fn make_rc_obj(value: u32) -> Rc<Obj> {
         Rc::new(make_obj(value))
@@ -2253,7 +2253,7 @@ mod tests {
             link: Link,
             value: &'a T,
         }
-        intrusive_adapter!(ObjAdapter<'a, T> = &'a Obj<'a, T>: Obj<'a, T> {link: Link} where T: 'a);
+        intrusive_adapter!(ObjAdapter<'a, T> = &'a Obj<'a, T>: Obj<'a, T> {link => Link} where T: 'a);
 
         let v = 5;
         let a = Obj {
@@ -2281,7 +2281,7 @@ mod tests {
                 self.value.set(val + 1);
             }
         }
-        intrusive_adapter!(ObjAdapter<'a> = Box<Obj<'a>>: Obj<'a> {link: Link});
+        intrusive_adapter!(ObjAdapter<'a> = Box<Obj<'a>>: Obj<'a> {link => Link});
 
         let v = Cell::new(0);
         let obj = Obj {
@@ -2314,7 +2314,7 @@ mod tests {
                 link: Link,
                 value: usize,
             }
-            intrusive_adapter!(ObjAdapter = $ptr<Obj>: Obj { link: Link });
+            intrusive_adapter!(ObjAdapter = $ptr<Obj>: Obj { link => Link });
 
             let a = $ptr::new(Obj {
                 link: Link::new(),


### PR DESCRIPTION
As the nested field access feature with `offset_of` is supported since Rust stable 1.82.0, it is time to support nested field access with `intrusive_adapter!` macro too!

Changes:

1. Support nested field access with macro `intrusive_adapter!` and `container_of`.
2. Replace `:` with `=>` to identify the link for the intrusive data structure. To support nested field access with `offset_of`, it requires the path to the link to be identified by `$($fields:expr)+`. Only `=>`, `,`, `;` can be used with the tailing `expr`. And `=>` suits the scenario here.

Example: (copied from the test)

```rust

#[cfg(test)]
mod tests {
    use crate::LinkedListLink;
    use std::rc::Rc;

    struct Obj {
        link: LinkedListLink,
    }

    struct Wrapper {
        obj: Obj,
    }

    intrusive_adapter! {
        /// Test doc comment
        ObjAdapter1 = Rc<Obj>: Obj { link => LinkedListLink }
    }

    intrusive_adapter! {
        /// Test doc comment
        WrapperAdapter1 = Rc<Wrapper>: Wrapper { obj.link => LinkedListLink }
    }
}

```

Requirements:

1. Bump MSRV to 1.82.0 .
2. Bump the major version of `intrusive-collections`.

FYI: 

1. Rust 1.82.0 release log: https://releases.rs/docs/1.82.0/#language
2. `offset_of_nested` stabilization PR: https://github.com/rust-lang/rust/pull/128284
